### PR TITLE
Simplify port fields by dropping _number

### DIFF
--- a/common_information_model/destination.md
+++ b/common_information_model/destination.md
@@ -8,5 +8,5 @@ Event fields used to define the destination in a network connection event.
 |--------|---------|-------|-------|
 | dst_ip | ip | destination IP in a network connection (IPv4) | 8.8.8.8 |
 | dst_host_name | string | Destination host name in a network connection| WKHR001 |
-| dst_port_number | integer | Destination port number used in a network connection | 53 |
+| dst_port | integer | Destination port number used in a network connection | 53 |
 | dst_port_name | string | Destination port name used in a network connection| DNS |

--- a/common_information_model/port.md
+++ b/common_information_model/port.md
@@ -6,7 +6,7 @@ Event fields used to define metadata about ports in a network connection.
 
 | Standard Name | Type | Description | Sample Value |
 |--------|---------|-------|-------|
-| src_port_number | integer | Source port number used in a network connection | 138 |
+| src_port | integer | Source port number used in a network connection | 138 |
 | src_port_name | string | Source port name used in a network connection | netbios-dgm |
-| dst_port_number | integer | Destination port number used in a network connection | 138 |
+| dst_port | integer | Destination port number used in a network connection | 138 |
 | dst_port_name | string | Destination port name used in a network connection | netbios-dgm |

--- a/common_information_model/source.md
+++ b/common_information_model/source.md
@@ -8,4 +8,4 @@ Event fields used to define the source in a network connection event.
 |--------|---------|-------|-------|
 | src_ip | ip | Source IP in a network connection (IPv4) | 8.8.8.8 |
 | src_host_name | string | Target host name in a network connection | WKHR001 |
-| src_port_number | integer | Source port number used in a network connection | 53 |
+| src_port | integer | Source port number used in a network connection | 53 |

--- a/data_dictionaries/windows/security/logon_logoff/event-4624.md
+++ b/data_dictionaries/windows/security/logon_logoff/event-4624.md
@@ -33,7 +33,7 @@ This event generates when a logon session is created (on destination machine). I
 |	process_id	|	ProcessId	|	integer	|	hexadecimal Process ID of the process that attempted the logon. Process ID (PID) is a number used by the operating system to uniquely identify an active process.	|	0x44c	|
 |	process_name	|	ProcessName	|	string	|	full path and the name of the executable for the process.	|	C:\\Windows\\System32\\svchost.exe	|
 |	src_ip	|	IpAddress	|	ip	|	IP address of machine from which logon attempt was performed	|	127.0.0.1	|
-|	src_port_number	|	IpPort	|	integer	|	source port which was used for logon attempt from remote machine. 0 for interactive logons	|	0	|
+|	src_port |	IpPort	|	integer	|	source port which was used for logon attempt from remote machine. 0 for interactive logons	|	0	|
 |	logon_impersonation_level	|	ImpersonationLevel	|	string	|	Impersonation level	|	%%1833	|
 |	logon_restricted_admin_mode	|	RestrictedAdminMode	|	string	|	Only populated for RemoteInteractive logon type sessions. This is a Yes/No flag indicating if the credentials provided were passed using Restricted Admin mode. Restricted Admin mode was added in Win8.1/2012R2 but this flag was added to the event in Win10. If not a RemoteInteractive logon, then this will be "-" string.	|	-	|
 |	user_network_account_name	|	TargetOutboundUserName	|	string	|	User name that will be used for outbound (network) connections. Valid only for NewCredentials logon type. If not NewCredentials logon, then this will be a "-" string.	|	-	|

--- a/data_dictionaries/windows/security/logon_logoff/event-4625.md
+++ b/data_dictionaries/windows/security/logon_logoff/event-4625.md
@@ -37,4 +37,4 @@ This event generates if an account logon attempt failed when the account was alr
 |	process_id	|	ProcessId	|	string	|	hexadecimal Process ID of the process that attempted the logon. Process ID (PID) is a number used by the operating system to uniquely identify an active process.	|	0x1bc	|
 |	process_name	|	ProcessName	|	ip	|	full path and the name of the executable for the process.	|	C:\\Windows\\System32\\winlogon.exe	|
 |	src_ip	|	IpAddress	|	integer	|	IP address of machine from which logon attempt was performed	|	127.0.0.1	|
-|	src_port_number	|	IpPort	|	string	|	source port which was used for logon attempt from remote machine. 0 for interactive logons	|	0	|
+|	src_port |	IpPort	|	string	|	source port which was used for logon attempt from remote machine. 0 for interactive logons	|	0	|

--- a/data_dictionaries/windows/security/logon_logoff/event-4648.md
+++ b/data_dictionaries/windows/security/logon_logoff/event-4648.md
@@ -30,4 +30,4 @@ This event is generated when a process attempts an account logon by explicitly s
 |	process_id	|	ProcessId	|	integer	|	hexadecimal Process ID of the process which was run using explicit credentials. Process ID (PID) is a number used by the operating system to uniquely identify an active process.	|	0x368	|
 |	process_name	|	ProcessName	|	string	|	full path and the name of the executable for the process.	|	C:\\Windows\\System32\\svchost.exe	|
 |	src_ip	|	IpAddress	|	ip	|	IP address of machine from which logon attempt was performed.	|	::1	|
-|	src_port_number	|	IpPort	|	integer	|	source port which was used for logon attempt from remote machine.	|	0	|
+|	src_port |	IpPort	|	integer	|	source port which was used for logon attempt from remote machine.	|	0	|

--- a/data_dictionaries/windows/sysmon/event-3.md
+++ b/data_dictionaries/windows/sysmon/event-3.md
@@ -73,9 +73,9 @@ The network connection event logs TCP/UDP connections on the machine. It is disa
 |	src_is_ipv6	|	SourceIsIpv6	|	boolean	|	is the source ip an Ipv6	|	FALSE	|
 |	src_ip	|	SourceIp	|	ip	|	source ip address that made the network connection	|	192.168.64.255	|
 |	src_host_name	|	SourceHostname	|	string	|	name of the host that made the network connection	|	computer_name or none for broadcast	|
-|	src_port_number	|	SourcePort	|	integer	|	source port number	|	138	|
+|	src_port |	SourcePort	|	integer	|	source port number	|	138	|
 |	src_port_name	|	SourcePortName	|	string	|	name of the source port being used (i.e. netbios-dgm)	|	netbios-dgm	|
 |	dst_is_ipv6	|	DestinationIsIpv6	|	boolean	|	is the destination ip an Ipv6	|	C:\Windows\System32\cmd.exe	|
 |	dst_ip	|	DestinationIp	|	ip	|	ip address destination	|	192.168.64.135	|
-|	dst_port_number	|	DestinationPort	|	integer	|	destination port number	|	138	|
+|	dst_port |	DestinationPort	|	integer	|	destination port number	|	138	|
 |	dst_port_name	|	DestinationPortName	|	string	|	name of the destination port	|	netbios-dgm	|

--- a/detection_data_model/data_objects/ip.md
+++ b/detection_data_model/data_objects/ip.md
@@ -7,9 +7,9 @@
 | ip_address | ip | IP address of the endpoint where the log was created | 8.8.8.8 |
 | dst_ip | ip | destination IP in a network connection (IPv4) | 8.8.8.8 |
 | src_ip | ip | source IP in a network connection (IPV4) | 192.168.1.2 |
-| src_port_number | integer | Source port number used in a network connection | 138 |
+| src_port | integer | Source port number used in a network connection | 138 |
 | src_port_name | string | Source port name used in a network connection | netbios-dgm |
-| dst_port_number | integer | Destination port number used in a network connection | 138 |
+| dst_port | integer | Destination port number used in a network connection | 138 |
 | dst_port_name | string | Destination port name used in a network connection | netbios-dgm |
 | dst_host_name | string | Destination host name in a network connection| WKHR001 |
 | src_host_name | string | name of the endpoint from which an event initiated in a network connection | WIN-GG82ULGC9GO |


### PR DESCRIPTION
The addition of the _number to dst_port and src_port does not add sufficient additional clarity for the additional length.  When writing queries, having the names just long enough, without redundancy is critical.