### PR TITLE
Fix Sysmon KQL parser output column casing

### DIFF
--- a/resources/scripts/ossemSysmonKQLParser.py
+++ b/resources/scripts/ossemSysmonKQLParser.py
@@ -82,7 +82,7 @@ for item in eventlist:
     for field in fieldlist:
         log.debug('Field Name: {}'.format(field['name']))
         field_name = dict()
-        field_name['name'] = field['name']
+        field_name['name'] = field['name'] if ("GUID" not in field['name']) else field['name'].replace('GUID', 'Guid')
         field_name['index'] = count
         sysmon_event['events'].append(field_name)
         count += 1


### PR DESCRIPTION
Event id 10 has a different casing for the word `GUID` compared to the other events. The columns are cased as `SourceProcessGUID` and `TargetProcessGUID` in Event id 10 while all other events use `SourceProcessGuid`, `TargetProcessGuid` and `ProcessGuid`. 

This results in output where columns cased in both ways exist, but only 1 contains the correct value, while the other one is empty. 

This makes it annoying to compare or join event types. It might also accidently introduce false negatives because both columns exists but are empty in some cases since the differently cased column should have been used.

This is a breaking change !